### PR TITLE
CORS proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "mocha": "^1.21.5",
     "request": "^2.45.0",
     "sinon": "^1.12.2",
-    "sinon-chai": "^2.6.0"
+    "sinon-chai": "^2.6.0",
+    "superagent-d2l-cors-proxy": "^0.0.2"
   },
   "dependencies": {
     "cors": "^2.5.2",

--- a/src/localAppResolver.js
+++ b/src/localAppResolver.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var os = require('os');
+var corsProxy = require('superagent-d2l-cors-proxy'),
+	os = require('os');
 
 function getHostname(opts) {
 	var hostname = opts.hostname || os.hostname();
@@ -34,6 +35,13 @@ LocalAppRegistry.prototype.host = function() {
 	app.get('/resolve/' + self._opts.key, function(req, res) {
 		res.json({ url: self.getConfigUrl() });
 	});
+
+	app.get(
+		corsProxy.getProxyDefaultLocation(),
+		function(req, res) {
+			res.sendFile(corsProxy.getProxyFilePath());
+		}
+	);
 
 	app.listen(self._opts.port);
 };

--- a/test/localAppResolver.js
+++ b/test/localAppResolver.js
@@ -1,5 +1,6 @@
-var appresolver = require('../src/localAppResolver');
-var request = require('request');
+var appresolver = require('../src/localAppResolver'),
+	corsProxy = require('superagent-d2l-cors-proxy'),
+	request = require('request');
 
 var KEY = 'whatevs';
 
@@ -80,6 +81,18 @@ describe('localAppResolver', function() {
 				} else {
 					cb();
 				}
+			});
+		});
+
+		it('should serve CORS proxy', function(cb) {
+			var url = 'http://localhost:3000' +
+				corsProxy.getProxyDefaultLocation();
+			request.get(url, function(err, res, body) {
+				if(err)
+					return cb(err);
+				if(res.statusCode !== 200)
+					return cb(res);
+				cb();
 			});
 		});
 


### PR DESCRIPTION
@cpacey 

This adds support to the local app resolver to host our new [CORS proxy endpoint](https://github.com/Brightspace/superagent-d2l-cors-proxy) as if it were the CDN.

Short version: IE9 doesn't support standard CORS, so we need to use a document hosted on the destination host (typically the CDN, but in this case it's the local app resolver) and open an IFRAME in the source host to that endpoint. Then IFRAMEs can then communicate using `postMessage` without needing to do CORSy things. [Long version](https://github.com/Brightspace/superagent-d2l-cors-proxy/blob/master/README.md).